### PR TITLE
feat: expose leafChunkTokens in plugin configSchema

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -111,6 +111,11 @@
       },
       "expansionProvider": {
         "type": "string"
+      },
+      "leafChunkTokens": {
+        "type": "integer",
+        "minimum": 1000,
+        "description": "Max source tokens per leaf compaction chunk (default 20000)"
       }
     }
   }


### PR DESCRIPTION
## Summary

Expose `leafChunkTokens` as a first-class plugin config option in `openclaw.plugin.json`, allowing users to tune leaf compaction frequency via `openclaw config set` without hitting schema validation errors.

## Problem

`leafChunkTokens` controls the maximum source tokens per leaf compaction chunk. The code already supports reading this value from plugin config (`config.leafChunkTokens`), but the plugin manifest `configSchema` does not include it. This means:

1. `openclaw config set plugins.entries.lossless-claw.config.leafChunkTokens 100000` fails with:
   ```
   Error: Config validation failed: plugins.entries.lossless-claw.config: invalid config: must NOT have additional properties
   ```
2. Users must either set the `LCM_LEAF_CHUNK_TOKENS` environment variable or manually patch the plugin manifest — both fragile workarounds that break on update.

## Why this matters

The default `leafChunkTokens` is 20,000 tokens. This was reasonable for smaller context windows (128K–200K), but for large-context models (e.g. Claude Opus with 1M tokens), the 20K default triggers leaf compaction far too aggressively:

- With `freshTailCount=64`, any raw messages outside the fresh tail accumulate quickly
- Once they hit 20K tokens (often just a few turns of conversation), `evaluateLeafTrigger()` fires
- This happens **regardless of `contextThreshold`** — even if you set `contextThreshold=0.75` (expecting compaction at 750K), the leaf trigger kicks in at ~20K
- Result: frequent premature compaction via the summary model, unnecessary context loss, and degraded conversation quality

Users with quota-limited summary providers (e.g. Gemini via Cloud Code Assist API) also hit rate limits due to excessive compaction calls.

## Related Issues & PRs

### Upstream (Martian-Engineering/lossless-claw)
- **[#218](https://github.com/Martian-Engineering/lossless-claw/issues/218)** — Feature request: expose `leafChunkTokens` as user-configurable parameter (reports same schema validation issue, workaround via manifest patching)
- **[#223](https://github.com/Martian-Engineering/lossless-claw/pull/223)** — PR implementing the same fix upstream (open, not yet merged)
- **[#221](https://github.com/Martian-Engineering/lossless-claw/pull/221)** — Updated default compaction settings (`freshTailCount` 32→64, `incrementalMaxDepth` 0→1), merged — but `leafChunkTokens` default was intentionally left at 20K for backward compatibility

### This repo
- No existing issue, but the CJK-aware token estimation in this fork makes the leaf trigger even more accurate (and thus more likely to fire at exactly 20K for CJK-heavy conversations).

## Changes

- **`openclaw.plugin.json`**: Add `leafChunkTokens` to `configSchema.properties` with type `integer`, minimum `1000`, and description
- No code changes needed — `resolveLcmConfig()` in `src/db/config.ts` already reads `leafChunkTokens` from plugin config

## Example usage

```json
{
  "plugins": {
    "entries": {
      "lossless-claw": {
        "config": {
          "freshTailCount": 64,
          "leafChunkTokens": 100000,
          "contextThreshold": 0.75,
          "incrementalMaxDepth": 1,
          "summaryModel": "anthropic/claude-haiku-4-5"
        }
      }
    }
  }
}
```

## Suggested values by context window size

| Context Window | Suggested `leafChunkTokens` | Rationale |
|---|---|---|
| 128K | 20,000 (default) | ~15% of window, reasonable frequency |
| 200K | 40,000–60,000 | Reduce compaction calls |
| 1M+ | 80,000–150,000 | Avoid premature compaction, preserve raw context |

## Backward compatibility

- Default value remains **20,000** (unchanged in `src/db/config.ts`)
- Environment variable `LCM_LEAF_CHUNK_TOKENS` still takes precedence
- Existing configs without `leafChunkTokens` are unaffected