### PR TITLE
fix: nonSpecialCount guard + deterministic generateSummaryId

### DIFF
--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -131,7 +131,7 @@ function generateSummaryId(content: string): string {
   return (
     "sum_" +
     createHash("sha256")
-      .update(content + Date.now().toString())
+      .update(content)
       .digest("hex")
       .slice(0, 16)
   );

--- a/src/estimate-tokens.ts
+++ b/src/estimate-tokens.ts
@@ -61,7 +61,7 @@ export function estimateTokens(text: string): number {
 
   // Supplementary chars consume 2 code units each in String.length
   const supplementaryCodeUnits = supplementaryCount * 2;
-  const nonSpecialCount = text.length - cjkCount - supplementaryCodeUnits;
+  const nonSpecialCount = Math.max(0, text.length - cjkCount - supplementaryCodeUnits);
 
   const tokens =
     cjkCount * CJK_TOKENS_PER_CHAR +


### PR DESCRIPTION
Two fixes applied before installation on Charon's RPi5:

**Fix 1 — estimate-tokens.ts: nonSpecialCount guard**
`Math.max(0, text.length - cjkCount - supplementaryCodeUnits)` prevents negative token counts when inputs contain extreme edge cases (e.g., all CJK chars or all supplementary code units).

**Fix 2 — compaction.ts: deterministic summary IDs**
`generateSummaryId` was calling `Date.now().toString()` in the hash, making summary IDs non-deterministic. Changed to content-only hash. Required for lossless expansion deduplication.

Both fixes verified on Charon's RPi5 (v0.5.2 installed, working).