### PR TITLE
fix: return registered context engine id for OpenClaw v2026.4.14

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1012,7 +1012,7 @@ export class LcmContextEngine implements ContextEngine {
     // Without a working schema, ownsCompaction would disable the runtime's
     // built-in compaction safeguard and inflate the context budget.
     this.info = {
-      id: "lcm",
+      id: "lossless-claw",
       name: "Lossless Context Management Engine",
       version: "0.1.0",
       ownsCompaction: migrationOk,


### PR DESCRIPTION
## Summary
Fix compatibility with OpenClaw v2026.4.14 by returning the registered context engine id expected by the runtime.

## Problem
OpenClaw v2026.4.14 rejects the plugin at runtime with:

```text
Context engine "lossless-claw" factory returned an invalid ContextEngine: info.id must match registered id "lossless-claw"
```

The engine currently reports:

```ts
id: "lcm"
```

but the registered plugin/context engine id is `lossless-claw`.

## Fix
Change the returned engine metadata from:

```ts
id: "lcm"
```

to:

```ts
id: "lossless-claw"
```

## Verification
- Reinstalled the patched plugin locally
- Restarted OpenClaw gateway
- Confirmed the previous `info.id must match registered id "lossless-claw"` runtime failure no longer appears
- Confirmed the plugin loads successfully after restart
