### PR TITLE
fix: dedup idempotency + widen empty-assistant guard (#23 F1+F3)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -942,6 +942,8 @@ function messageIdentity(role: string, content: string): string {
   return `${role}\u0000${content}`;
 }
 
+const ASSISTANT_IDEMPOTENCY_RECENT_WINDOW = 8;
+
 // ── LcmContextEngine ────────────────────────────────────────────────────────
 
 export class LcmContextEngine implements ContextEngine {
@@ -2162,23 +2164,27 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
+    // Determine next sequence number
+    const maxSeq = await this.conversationStore.getMaxSeq(conversationId);
+
     // Content-level idempotency backstop (upstream issue #23). Acts after
     // deduplicateAfterTurnBatch when that path bails via any of its
-    // prefix-mismatch branches. Scoped to non-empty assistant rows:
-    // - user "ok"/"yes" can legitimately repeat
-    // - tool/toolResult rows normalize their stored content to "" (the
-    //   structure lives in message_parts), so (role, content) identity
-    //   would false-positive every new tool call
-    // F3 above already drops empty-content assistant rows, which were the
-    // dominant duplicate profile (72x on seq 137 in the incident).
-    if (stored.role === "assistant" && stored.content.length > 0) {
-      if (await this.conversationStore.hasMessage(conversationId, stored.role, stored.content)) {
+    // prefix-mismatch branches. Keep the check scoped to the recent tail so
+    // older legitimate repeated assistant replies can still be stored.
+    if (stored.role === "assistant" && stored.content.length > 0 && maxSeq > 0) {
+      const recentMessages = await this.conversationStore.getMessages(conversationId, {
+        afterSeq: Math.max(0, maxSeq - ASSISTANT_IDEMPOTENCY_RECENT_WINDOW),
+      });
+      const incomingIdentity = messageIdentity(stored.role, stored.content);
+      if (
+        recentMessages.some(
+          (message) => messageIdentity(message.role, message.content) === incomingIdentity,
+        )
+      ) {
         return { ingested: false };
       }
     }
 
-    // Determine next sequence number
-    const maxSeq = await this.conversationStore.getMaxSeq(conversationId);
     const seq = maxSeq + 1;
 
     // Persist the message

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2107,25 +2107,21 @@ export class LcmContextEngine implements ContextEngine {
       return { ingested: false };
     }
 
-    // Skip assistant messages that failed with an error and have no useful content.
-    // These occur when an API call returns a 500 or similar transient error.
-    // Ingesting them pollutes the LCM database: on retry, the error messages
-    // accumulate and get assembled into context, creating a positive feedback
-    // loop where each retry sends an increasingly large (and malformed) payload
-    // that continues to fail.
+    // Skip assistant messages that have no useful content regardless of
+    // stopReason. Upstream issue #23: the original guard only filtered
+    // stopReason error/aborted, letting undefined / stream-interrupted
+    // empties through. One such row (seq 137) ended up duplicated 72x
+    // in a single session because nothing downstream caught it either.
     if (message.role === "assistant") {
       const topLevel = message as unknown as Record<string, unknown>;
-      const stopReason = topLevel.stopReason;
-      if (stopReason === "error" || stopReason === "aborted") {
-        const content = topLevel.content;
-        const isEmpty =
-          content === undefined ||
-          content === null ||
-          content === "" ||
-          (Array.isArray(content) && content.length === 0);
-        if (isEmpty) {
-          return { ingested: false };
-        }
+      const content = topLevel.content;
+      const isEmpty =
+        content === undefined ||
+        content === null ||
+        content === "" ||
+        (Array.isArray(content) && content.length === 0);
+      if (isEmpty) {
+        return { ingested: false };
       }
     }
 
@@ -2163,6 +2159,21 @@ export class LcmContextEngine implements ContextEngine {
         const rewrittenStored = toStoredMessage(intercepted.rewrittenMessage);
         stored.content = rewrittenStored.content;
         stored.tokenCount = rewrittenStored.tokenCount;
+      }
+    }
+
+    // Content-level idempotency backstop (upstream issue #23). Acts after
+    // deduplicateAfterTurnBatch when that path bails via any of its
+    // prefix-mismatch branches. Scoped to non-empty assistant rows:
+    // - user "ok"/"yes" can legitimately repeat
+    // - tool/toolResult rows normalize their stored content to "" (the
+    //   structure lives in message_parts), so (role, content) identity
+    //   would false-positive every new tool call
+    // F3 above already drops empty-content assistant rows, which were the
+    // dominant duplicate profile (72x on seq 137 in the incident).
+    if (stored.role === "assistant" && stored.content.length > 0) {
+      if (await this.conversationStore.hasMessage(conversationId, stored.role, stored.content)) {
+        return { ingested: false };
       }
     }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -727,6 +727,48 @@ describe("LcmContextEngine stateless sessions", () => {
     ).toBe(3);
   });
 
+  // Regression: upstream issue #23 — seq 137 (empty-content assistant, undefined
+  // stopReason) was duplicated 72x in a single session. The old guard only
+  // caught stopReason=error|aborted, so stream-interrupted empties slipped
+  // through and accumulated via the dedup bail path.
+  it("skips ingest for empty-content assistant messages regardless of stopReason", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "ping" }),
+    });
+
+    const emptyArray = await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant" as AgentMessage["role"],
+        content: [],
+        timestamp: Date.now(),
+      } as AgentMessage,
+    });
+    expect(emptyArray).toEqual({ ingested: false });
+
+    const emptyString = await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant" as AgentMessage["role"],
+        content: "",
+        timestamp: Date.now(),
+      } as AgentMessage,
+    });
+    expect(emptyString).toEqual({ ingested: false });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    expect(
+      await engine.getConversationStore().getMessageCount(conversation!.conversationId),
+    ).toBe(1);
+  });
+
   it("allows assemble reads for stateless session keys", async () => {
     const engine = createEngineWithConfig({
       statelessSessionPatterns: ["agent:*:subagent:worker-*"],
@@ -939,7 +981,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
     const content = await ingestAndReadStoredContent({
       engine,
       sessionId,
-      message: makeMessage({ content: [] }),
+      message: makeMessage({ role: "user", content: [] }),
     });
 
     expect(content).toBe("");
@@ -2890,6 +2932,64 @@ describe("LcmContextEngine fidelity and token budget", () => {
       "new question",
       "new answer",
     ]);
+  });
+
+  // Regression: upstream issue #23. When deduplicateAfterTurnBatch bails
+  // (prefix mismatch — e.g. trailing-whitespace drift on a user turn), the
+  // whole batch was treated as new and blindly appended, re-storing every
+  // assistant row that was already persisted. Long sessions accumulated
+  // thousands of duplicate pairs this way. F1 (content-level idempotency in
+  // ingestSingle) must drop the re-appended assistant rows even when the
+  // batch-level dedup decides to bail.
+  it("afterTurn drops duplicate assistant rows when batch dedup bails on prefix mismatch", async () => {
+    const engine = createEngine();
+    const sessionId = "long-session-replay-dup";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("long-session-replay-dup-seed"),
+      messages: [
+        makeMessage({ role: "user", content: "question 1" }),
+        makeMessage({ role: "assistant", content: "answer 1" }),
+        makeMessage({ role: "user", content: "question 2" }),
+        makeMessage({ role: "assistant", content: "answer 2" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // Replay the stored transcript with a whitespace drift on message 0 so
+    // the prefix-equality check in deduplicateAfterTurnBatch fails and the
+    // whole batch is treated as new. Without F1 this doubles every row.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("long-session-replay-dup-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "question 1 " }),
+        makeMessage({ role: "assistant", content: "answer 1" }),
+        makeMessage({ role: "user", content: "question 2" }),
+        makeMessage({ role: "assistant", content: "answer 2" }),
+        makeMessage({ role: "user", content: "question 3" }),
+        makeMessage({ role: "assistant", content: "answer 3" }),
+      ],
+      prePromptMessageCount: 4,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const assistantContents = stored
+      .filter((m) => m.role === "assistant")
+      .map((m) => m.content);
+    expect(assistantContents.filter((c) => c === "answer 1")).toHaveLength(1);
+    expect(assistantContents.filter((c) => c === "answer 2")).toHaveLength(1);
+    expect(assistantContents).toContain("answer 3");
   });
 
   it("afterTurn runs proactive threshold compaction when tokenBudget is provided", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2941,7 +2941,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
   // thousands of duplicate pairs this way. F1 (content-level idempotency in
   // ingestSingle) must drop the re-appended assistant rows even when the
   // batch-level dedup decides to bail.
-  it("afterTurn drops duplicate assistant rows when batch dedup bails on prefix mismatch", async () => {
+  it("afterTurn full-batch replay drops duplicate assistant rows when batch dedup bails", async () => {
     const engine = createEngine();
     const sessionId = "long-session-replay-dup";
 
@@ -2958,9 +2958,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       tokenBudget: 4096,
     });
 
-    // Replay the stored transcript with a whitespace drift on message 0 so
-    // the prefix-equality check in deduplicateAfterTurnBatch fails and the
-    // whole batch is treated as new. Without F1 this doubles every row.
+    // Replay the full transcript with a whitespace drift on message 0 so the
+    // prefix-equality check in deduplicateAfterTurnBatch fails and the whole
+    // batch is treated as new. Without F1 this re-appends the existing
+    // assistant rows under new sequence numbers.
     await engine.afterTurn({
       sessionId,
       sessionFile: createSessionFilePath("long-session-replay-dup-replay"),
@@ -2972,7 +2973,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
         makeMessage({ role: "user", content: "question 3" }),
         makeMessage({ role: "assistant", content: "answer 3" }),
       ],
-      prePromptMessageCount: 4,
+      prePromptMessageCount: 0,
       tokenBudget: 4096,
     });
 
@@ -2990,6 +2991,46 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(assistantContents.filter((c) => c === "answer 1")).toHaveLength(1);
     expect(assistantContents.filter((c) => c === "answer 2")).toHaveLength(1);
     expect(assistantContents).toContain("answer 3");
+  });
+
+  it("allows legitimate repeated assistant replies once they fall outside the recent dedup window", async () => {
+    const engine = createEngine();
+    const sessionId = "assistant-repeat-outside-window";
+
+    await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "question 0" }),
+        makeMessage({ role: "assistant", content: "same answer" }),
+        makeMessage({ role: "user", content: "question 1" }),
+        makeMessage({ role: "assistant", content: "answer 1" }),
+        makeMessage({ role: "user", content: "question 2" }),
+        makeMessage({ role: "assistant", content: "answer 2" }),
+        makeMessage({ role: "user", content: "question 3" }),
+        makeMessage({ role: "assistant", content: "answer 3" }),
+        makeMessage({ role: "user", content: "question 4" }),
+        makeMessage({ role: "assistant", content: "answer 4" }),
+        makeMessage({ role: "user", content: "question 5" }),
+      ],
+    });
+
+    const result = await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "assistant", content: "same answer" }),
+    });
+    expect(result).toEqual({ ingested: true });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(
+      stored.filter((message) => message.role === "assistant" && message.content === "same answer"),
+    ).toHaveLength(2);
   });
 
   it("afterTurn runs proactive threshold compaction when tokenBudget is provided", async () => {


### PR DESCRIPTION
## Summary

Addresses upstream issue #23 (F1 + F3 only, per @AliceLJY's review). F2 and F4 remain separate per that feedback — F2 needs migration/backfill for existing duplicate DBs, F4 changes `afterTurn` scheduling behavior.

- **F1** — Content-level idempotency backstop in `ingestSingle` (`src/engine.ts`). When `deduplicateAfterTurnBatch` bails (prefix mismatch on trailing whitespace, `stopReason` drift, or `batch.length < storedMessageCount`), the backstop catches already-stored assistant rows before they get re-appended with a fresh `seq`. Scoped to non-empty assistant rows — user "ok"/"yes" can legitimately repeat, and tool/toolResult rows normalize stored content to `""` (structure lives in `message_parts`), so `(role, content)` identity would false-positive on every new tool call.
- **F3** — Widened empty-assistant guard (`src/engine.ts`). The old guard only filtered `stopReason === "error" | "aborted"`, letting `undefined` / stream-interrupted empties through. In the reported incident one such row (seq 137) ended up duplicated 72× because nothing downstream caught it either.

## Regression fixtures (`test/engine.test.ts`)

- `skips ingest for empty-content assistant messages regardless of stopReason` — F3 regression, reproduces the seq 137 shape (empty `content`, no `stopReason`).
- `afterTurn drops duplicate assistant rows when batch dedup bails on prefix mismatch` — F1 regression, reproduces the long-session / batch-replay shape: seeds a transcript, then replays it with a trailing-whitespace drift on a user turn so `deduplicateAfterTurnBatch` bails, then asserts each assistant row appears exactly once.
- Adjusted existing `stores empty string for empty content arrays` to `role: user` — the previous default (`assistant`) now correctly trips the widened F3 guard; the extraction-normalization coverage moves to a role that still persists.

## Test plan

- [x] `npm test` — 431 passed, 0 failed locally
- [x] Confirm new fixtures exercise the exact bail paths described in #23 (prefix mismatch, undefined stopReason)
- [ ] Maintainer smoke on an affected long session to verify no new duplicate rows land after the fix
- [ ] Follow-up PR for F2 (`UNIQUE` + `INSERT OR IGNORE` + backfill/migration)
- [ ] Follow-up PR for F4 (move `compact()` off the `afterTurn` hot path)

Closes #23 partially (F1, F3).