### PR TITLE
docs: clarify OpenClaw 5 config fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,34 @@ Restart the gateway after configuration changes:
 openclaw gateway restart
 ```
 
+#### OpenClaw 2026.5.x config validation
+
+Some OpenClaw 2026.5.x builds validate `openclaw.json` before plugin schemas are
+loaded. In that case, putting custom plugin config under
+`plugins.entries.lossless-claw.config` can fail with:
+
+```text
+OpenClaw config is invalid: ~/.openclaw/openclaw.json
+  x plugins: Invalid input
+```
+
+If you see that error, keep only the slot/enablement settings in
+`openclaw.json` and set LCM tuning through environment variables instead. For
+example:
+
+```bash
+export LCM_SUMMARY_MODEL=minimax/MiniMax-M2.5
+export LCM_EXPANSION_MODEL=minimax/MiniMax-M2.5
+# Optional when the model string does not include a provider prefix:
+export LCM_SUMMARY_PROVIDER=minimax
+export LCM_EXPANSION_PROVIDER=minimax
+```
+
+The plugin still supports `summaryModel`, `summaryProvider`, `expansionModel`,
+and `expansionProvider` when the OpenClaw host accepts plugin config objects;
+environment variables are the compatible path for strict 2026.5.x config
+validators.
+
 ### Update to latest
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,6 +58,19 @@ openclaw plugins enable lossless-claw
 }
 ```
 
+> **OpenClaw 2026.5.x 提示：** 如果 `openclaw.json` 校验报
+> `plugins: Invalid input`，说明当前 OpenClaw host 还没有在配置校验阶段接受
+> `plugins.entries.lossless-claw.config` 里的插件自定义字段。此时只在
+> `openclaw.json` 保留 `plugins.slots.contextEngine = "lossless-claw"`，
+> 模型覆盖改用环境变量：
+>
+> ```bash
+> export LCM_SUMMARY_MODEL=minimax/MiniMax-M2.5
+> export LCM_EXPANSION_MODEL=minimax/MiniMax-M2.5
+> export LCM_SUMMARY_PROVIDER=minimax
+> export LCM_EXPANSION_PROVIDER=minimax
+> ```
+
 ## 本 Fork 的修復
 
 ### 1. `getApiKey()` Provider Config Fallback

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,33 @@ export LCM_INCREMENTAL_MAX_DEPTH=-1
 
 Restart OpenClaw.
 
+### OpenClaw 2026.5.x config validation
+
+Some OpenClaw 2026.5.x builds validate `openclaw.json` before plugin schemas are
+loaded. On those builds, custom plugin config under
+`plugins.entries.lossless-claw.config` may be rejected with:
+
+```text
+OpenClaw config is invalid: ~/.openclaw/openclaw.json
+  x plugins: Invalid input
+```
+
+When that happens, keep only plugin enablement and the context-engine slot in
+`openclaw.json`, then use environment variables for LCM tuning:
+
+```bash
+export LCM_SUMMARY_MODEL=minimax/MiniMax-M2.5
+export LCM_EXPANSION_MODEL=minimax/MiniMax-M2.5
+# Optional when the model name is bare:
+export LCM_SUMMARY_PROVIDER=minimax
+export LCM_EXPANSION_PROVIDER=minimax
+```
+
+The plugin still reads `summaryModel`, `summaryProvider`, `expansionModel`, and
+`expansionProvider` from plugin config when the OpenClaw host accepts plugin
+config objects. Environment variables are the compatible path for strict
+2026.5.x validators.
+
 ## Tuning guide
 
 ### Context threshold

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -36,6 +36,32 @@ export LCM_INCREMENTAL_MAX_DEPTH=-1
 
 然后重启 OpenClaw。
 
+### OpenClaw 2026.5.x 配置校验
+
+部分 OpenClaw 2026.5.x 版本会在加载插件 schema 之前先校验
+`openclaw.json`。在这些版本里，把自定义插件配置写到
+`plugins.entries.lossless-claw.config` 下面，可能会报：
+
+```text
+OpenClaw config is invalid: ~/.openclaw/openclaw.json
+  x plugins: Invalid input
+```
+
+遇到这个错误时，建议 `openclaw.json` 里只保留插件启用和
+context-engine slot，LCM 参数改用环境变量：
+
+```bash
+export LCM_SUMMARY_MODEL=minimax/MiniMax-M2.5
+export LCM_EXPANSION_MODEL=minimax/MiniMax-M2.5
+# 如果模型名没有 provider 前缀，再加：
+export LCM_SUMMARY_PROVIDER=minimax
+export LCM_EXPANSION_PROVIDER=minimax
+```
+
+当 OpenClaw host 接受 plugin config object 时，插件仍然支持
+`summaryModel`、`summaryProvider`、`expansionModel`、`expansionProvider`。
+对严格的 2026.5.x 配置校验器来说，环境变量是兼容路径。
+
 ## 调优指南
 
 ### 上下文阈值


### PR DESCRIPTION
## Summary
- document the OpenClaw 2026.5.x config validation failure mode
- recommend environment variables for model overrides when plugin config objects are rejected
- mirror the guidance in English and Chinese docs

## Validation
- npm ci
- npm test
- git diff --check

Docs-only change; no changeset needed.

Fixes #30